### PR TITLE
use up to date deno std library version

### DIFF
--- a/lines.ts
+++ b/lines.ts
@@ -1,5 +1,5 @@
-import { TextProtoReader } from 'https://deno.land/std@v0.12/textproto/mod.ts';
-import { BufReader } from 'https://deno.land/std@v0.12/io/bufio.ts';
+import { TextProtoReader } from 'https://deno.land/std/textproto/mod.ts';
+import { BufReader } from 'https://deno.land/std/io/bufio.ts';
 
 /** Yields a buffer of each line given from the reader. */
 export async function* linesBuffer(


### PR DESCRIPTION
removing the version numbers from deno/std/io/bufio (and /textproto, too). This way the code works again as expected, not resulting in any 404s. This fixes #1 

For anyone else needing this in the meantime, you can use

    import { input } from "https://raw.githubusercontent.com/phil294/read_lines/v3.0.1/input.ts"

instead which includes the patch