### PR TITLE
Remove version pinning

### DIFF
--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,5 +1,5 @@
-export { runTests, test } from "https://deno.land/std@v0.3.4/testing/mod.ts";
+export { runTests, test } from "https://deno.land/std/testing/mod.ts"
 export {
 	assertEquals,
-	assertThrowsAsync
-} from "https://deno.land/std@v0.3.4/testing/asserts.ts";
+	assertThrowsAsync,
+} from "https://deno.land/std/testing/asserts.ts"


### PR DESCRIPTION
trying to use this module yields the following error:

```
Compile file:///home/jorge/code/javascript/deno/prueba1/main.ts
Download https://raw.githubusercontent.com/johnsonjo4531/read_lines/v2.1.0/examples/input.ts
Download https://raw.githubusercontent.com/johnsonjo4531/read_lines/v2.1.0/input.ts
Download https://raw.githubusercontent.com/johnsonjo4531/read_lines/v2.1.0/lines.ts
Download https://deno.land/x/io@v0.3.4/bufio.ts
error: Uncaught Other: Import 'https://deno.land/x/io@v0.3.4/bufio.ts' failed: 404 Not Found
► $deno$/dispatch_json.ts:40:11
    at DenoError ($deno$/errors.ts:20:5)
    at unwrapResponse ($deno$/dispatch_json.ts:40:11)
    at sendAsync ($deno$/dispatch_json.ts:91:10)
```

I don't know a lot about Deno but maybe pinning an import of std to v0.3.4 is what causes this thing
to fail to compile