### PR TITLE
Deno.EOF doesn't exist in newer versions of Deno

### DIFF
--- a/input.ts
+++ b/input.ts
@@ -11,13 +11,13 @@ export function inputReader(
 	 * the line read and at the second index a boolean indicating whether the eof
 	 * has been reached.
 	 */
-	return async function input(output: string): Promise<string | Deno.EOF> {
+	return async function input(output: string): Promise<string | null> {
 		if (output) {
 			writer.write(new TextEncoder().encode(output));
 		}
 		const { value, done } = await lineReader.next();
 		if (done) {
-			return Deno.EOF
+			return null
 		}
 		return value;
 	};

--- a/lines.ts
+++ b/lines.ts
@@ -1,5 +1,5 @@
 type Reader = Deno.Reader;
-import { readDelim, readLines } from 'https://deno.land/std@v0.36.0/io/bufio.ts';
+import { readDelim, readLines } from 'https://deno.land/std@v0.42.0/io/bufio.ts';
 
 /** Yields a buffer of each line given from the reader. */
 /** Read delimited strings from a Reader. */


### PR DESCRIPTION
I get an error about `Deno.EOF` not existing. I guess we're just supposed to use `null` now so this PR addresses that, along with an updated version of the library.